### PR TITLE
Use correct file pattern to include fonts files in the distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@ setup(name='pyfiglet',
       author_email='peter.waller@gmail.com',
       url='https://github.com/pwaller/pyfiglet',
       packages=['pyfiglet', 'pyfiglet.fonts'],
-      package_data={'pyfiglet.fonts' : ['pyfiglet/fonts/*.flf']},
+      package_data={'pyfiglet.fonts' : ['*.flf']},
 )
 


### PR DESCRIPTION
Currently fonts files are not included on installation. This change corrects it.
