### PR TITLE
Export PYTHONPATH, to ensure we can find the fonts with pkg_resources

### DIFF
--- a/tools/pyfiglet
+++ b/tools/pyfiglet
@@ -1,3 +1,5 @@
 #!/bin/sh
 
-exec python "$(dirname "$0")"/../pyfiglet/__init__.py "$@"
+cd "$(dirname "$0")"/..
+export PYTHONPATH=$(pwd)
+exec python pyfiglet/__init__.py "$@"


### PR DESCRIPTION
Fixes this problem for me:

```
$ tools/pyfiglet -l
Traceback (most recent call last):
  File "tools/../pyfiglet/__init__.py", line 516, in <module>
    sys.exit(main())
  File "tools/../pyfiglet/__init__.py", line 490, in main
    print FigletFont.getFonts()
  File "tools/../pyfiglet/__init__.py", line 99, in getFonts
    in pkg_resources.resource_listdir('pyfiglet', 'fonts')
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 921, in resource_listdir
    return get_provider(package_or_requirement).resource_listdir(
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 213, in get_provider
    __import__(moduleOrReq)
ImportError: No module named pyfiglet
```
