### PR TITLE
make font list human-readable and parsable

### DIFF
--- a/pyfiglet/__init__.py
+++ b/pyfiglet/__init__.py
@@ -511,7 +511,7 @@ def main():
     opts, args = parser.parse_args()
 
     if opts.list_fonts:
-        print(FigletFont.getFonts())
+        print('\n'.join(sorted(FigletFont.getFonts())))
         exit(0)
 
     if opts.info_font:


### PR DESCRIPTION
I noticed that `-l` output the representation of `list`, which is hard to read and different than `figlist`, which lists like:

```
$ figlist | head -5
Default font: standard
Font directory: /usr/share/figlet
Figlet fonts in this directory:
1943____
3-d
```

I thought about mimic the exact format, but I think one font name per line is enough to be readable and parsable easily.
