### PR TITLE
Don't Leak File Handles

### DIFF
--- a/pyfiglet/__init__.py
+++ b/pyfiglet/__init__.py
@@ -110,6 +110,7 @@ class FigletFont(object):
             return False
         f = pkg_resources.resource_stream('pyfiglet.fonts', font)
         header = f.readline().decode('UTF-8', 'replace')
+        f.close()
         return cls.reMagicNumber.search(header)
 
     @classmethod


### PR DESCRIPTION
In pypy, which is garbage collected rather than refcounted, open file handles can sometimes collect too quickly for the garbage collector and trigger the operating system's file handle limit.

In my test code, I was seeing this failure:

```
ERROR: Failure: IOError ([Errno 24] Too many open files: u'/Users/llimllib/.virtualenvs/limbopypy/site-packages/pyfiglet/fonts/stellar.flf')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/llimllib/.virtualenvs/limbopypy/site-packages/nose/loader.py", line 414, in loadTestsFromName
    addr.filename, addr.module)
  File "/Users/llimllib/.virtualenvs/limbopypy/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/Users/llimllib/.virtualenvs/limbopypy/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/Users/llimllib/code/limbo/test/test_plugins/test_banner.py", line 10, in <module>
    from banner import on_message
  File "/Users/llimllib/code/limbo/test/test_plugins/../../limbo/plugins/banner.py", line 9, in <module>
    FONTS = FIGLET.getFonts()
  File "/Users/llimllib/.virtualenvs/limbopypy/site-packages/pyfiglet/__init__.py", line 750, in getFonts
    return self.Font.getFonts()
  File "/Users/llimllib/.virtualenvs/limbopypy/site-packages/pyfiglet/__init__.py", line 119, in getFonts
    if cls.isValidFont(font)]
  File "/Users/llimllib/.virtualenvs/limbopypy/site-packages/pyfiglet/__init__.py", line 111, in isValidFont
    f = pkg_resources.resource_stream('pyfiglet.fonts', font)
  File "/Users/llimllib/.virtualenvs/limbopypy/site-packages/pkg_resources/__init__.py", line 1161, in resource_stream
    self, resource_name
  File "/Users/llimllib/.virtualenvs/limbopypy/site-packages/pkg_resources/__init__.py", line 1715, in get_resource_stream
    return open(self._fn(self.module_path, resource_name), 'rb')
IOError: [Errno 24] Too many open files: u'/Users/llimllib/.virtualenvs/limbopypy/site-packages/pyfiglet/fonts/stellar.flf'
```

As soon as I patched pyfiglet's getFont method to close the file handle, all my tests passed.

I don't know much about pkg_resources, but the [docs promise](https://pythonhosted.org/setuptools/pkg_resources.html#basic-resource-access) that the result of `resource_stream` should be a file-like object, and so .close() should be legal on it.