### PR TITLE
In Python 3, args are already decoded

### DIFF
--- a/pyfiglet/__init__.py
+++ b/pyfiglet/__init__.py
@@ -792,7 +792,7 @@ def main():
         return 1
 
     if sys.version_info < (3,):
-        args = map(lambda arg: arg.decode(sys.stdout.encoding), args)
+        args = [arg.decode('UTF-8') for arg in args]
 
     text = ' '.join(args)
 

--- a/pyfiglet/__init__.py
+++ b/pyfiglet/__init__.py
@@ -791,7 +791,8 @@ def main():
         parser.print_help()
         return 1
 
-    args = map(lambda arg: arg.decode(sys.stdout.encoding), args)
+    if sys.version_info < (3,):
+        args = map(lambda arg: arg.decode(sys.stdout.encoding), args)
 
     text = ' '.join(args)
 


### PR DESCRIPTION
Avoids a crash on startup.