### PR TITLE
Add LICENSE to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include pyfiglet/fonts/*.flf
 include pyfiglet/fonts/*.flc
+include LICENSE
 recursive-include doc *


### PR DESCRIPTION
Hey-lo,

I'm building a version of `pyfiglet` using [`conda`](http://conda.pydata.org/) for [conda-forge](http://conda-forge.github.io/). When possible, we try to include a link to the license file in the `meta.yaml` specification for the build; doing so requires the license be indexed in an explicit [`MANIFEST.in`](https://docs.python.org/2/distutils/sourcedist.html#manifest-related-options) file so that it gets included in the source distribution.

This pull should make sure that the license gets included the next time you do a source build.