### PR TITLE
Update setup.py for python 3.6 and 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,8 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Text Processing',
         'Topic :: Text Processing :: Fonts',
     ],


### PR DESCRIPTION
This seems to be working for python 3.7 at least (see below). Not extensively tested though. 

```
06:33 $ pip install git+https://github.com/BjornFJohansson/pyfiglet.git
Collecting git+https://github.com/BjornFJohansson/pyfiglet.git
  Cloning https://github.com/BjornFJohansson/pyfiglet.git to /tmp/pip-req-build-qmt3_jfv
Building wheels for collected packages: pyfiglet
  Running setup.py bdist_wheel for pyfiglet ... done
  Stored in directory: /tmp/pip-ephem-wheel-cache-_0kedwwd/wheels/9e/0f/99/d7d96f134746e4478b330019e13355dcb3abc078c16e9a5148
Successfully built pyfiglet
Installing collected packages: pyfiglet
Successfully installed pyfiglet-0.8.post0



06:40 $ python
Python 3.7.0 | packaged by conda-forge | (default, Jul 23 2018, 21:39:36) 
[GCC 4.8.2 20140120 (Red Hat 4.8.2-15)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from pyfiglet import Figlet
>>> f=Figlet(font='standard')
>>> print(f.renderText("abcdefghijklmnopqrstuvxyz")
... )
       _             _       __       _     _  _ _    _                       
  __ _| |__   ___ __| | ___ / _| __ _| |__ (_)(_) | _| |_ __ ___  _ __   ___  
 / _` | '_ \ / __/ _` |/ _ \ |_ / _` | '_ \| || | |/ / | '_ ` _ \| '_ \ / _ \ 
| (_| | |_) | (_| (_| |  __/  _| (_| | | | | || |   <| | | | | | | | | | (_) |
 \__,_|_.__/ \___\__,_|\___|_|  \__, |_| |_|_|/ |_|\_\_|_| |_| |_|_| |_|\___/ 
                                |___/       |__/                              
                      _                               
 _ __   __ _ _ __ ___| |_ _   ___   ____  ___   _ ____
| '_ \ / _` | '__/ __| __| | | \ \ / /\ \/ / | | |_  /
| |_) | (_| | |  \__ \ |_| |_| |\ V /  >  <| |_| |/ / 
| .__/ \__, |_|  |___/\__|\__,_| \_/  /_/\_\\__, /___|
|_|       |_|                               |___/     

>>> 
```