### PR TITLE
Add 'make publish' which also publishes wheel (0.8.post1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+all:
+	@echo 'Run "make publish" to do "python setup.py sdist bdist_wheel upload"'
+
+publish:
+	python setup.py sdist bdist_wheel upload

--- a/pyfiglet/version.py
+++ b/pyfiglet/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.8.post0'
+__version__ = '0.8.post1'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
Also bump version to 0.8.post1.

Post release version is used because there is no material change from
0.8, only a change to the packaging process.

Fixes #66.

/cc @SecT0uch to confirm it works for him.