### PR TITLE
Adding Power support(ppc64le) with continuous integration/testing to the project for architecture independent.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+arch:
+ - amd64
+ - ppc64le
 python:
  - "2.7"
  - "3.5"
@@ -8,6 +11,12 @@ python:
  - "3.9"
  - "pypy"
  - "pypy3"
+jobs:
+  exclude:
+   - arch : ppc64le
+     python : pypy
+   - arch : ppc64le
+     python : pypy3	 
 before_install:
  - "sudo apt-get update -qq"
  - "sudo apt-get install -qq toilet figlet"


### PR DESCRIPTION
I am part of IBM team and working on porting power arch to packages as continuous integration & testing.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and ISVs, and while we don't use this package directly,

we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model,For more info tag @gerrith3.
Pls verify and merg