### PR TITLE
Support caca2tlf converted fonts better

### DIFF
--- a/pyfiglet/__init__.py
+++ b/pyfiglet/__init__.py
@@ -312,7 +312,7 @@ class FigletFont(object):
                     line = data.pop(0)
                     if end is None:
                         end = self.reEndMarker.search(line).group(1)
-                        end = re.compile(re.escape(end) + r'{1,2}$')
+                        end = re.compile(re.escape(end) + r'{1,2}\s*$')
 
                     line = end.sub('', line)
 


### PR DESCRIPTION
Fix missing possible end spacer on caca2tlf converted fonts. (final '@ ' on every char lines)