### PR TITLE
Add loading German Umlaute

### DIFF
--- a/pyfiglet/__init__.py
+++ b/pyfiglet/__init__.py
@@ -328,6 +328,13 @@ class FigletFont(object):
                     self.chars[i] = letter
                     self.width[i] = width
 
+            # Load German Umlaute - the follow directly after standard character 127
+            for i in 'ÄÖÜäöüß':
+                width, letter = __char(data)
+                if ''.join(letter) != '':
+                    self.chars[ord(i)] = letter
+                    self.width[ord(i)] = width
+
             # Load ASCII extended character set
             while data:
                 line = data.pop(0).strip()


### PR DESCRIPTION
The German Umlaute (ÄÖÜäöüß) are following directly to the standard characters (32-127) in the font files.

Many fonts have them defined. But with the current logic they are ignored and not loaded.

This will fix ticket #80 