### PR TITLE
Update test.yml python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7.18, 3.5.10, 3.10.11, 3.11.3, pypy2, pypy3]
+        python-version: [2.7.18, 3.10.11, 3.11.3, pypy2.7, pypy3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, pypy2, pypy3]
+        python-version: [2.7.18, 3.5.10, 3.10.11, 3.11.3, pypy2, pypy3]
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
Rationale: one 2.7 version, and the two most recent versions, and pypy2+3.

I was unable to test older python versions without more effort since they aren't supported by gh actions on Ubuntu 22.04.