### PR TITLE
Fix #95 - Default fonts if user just runs setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,15 @@
 
 from setuptools import setup
 import sys
+from os import path
+import shutil
 
+# Set up minimum fonts if none already present
+here = path.abspath(path.dirname(__file__))
+pkg_src = path.join(here, 'pyfiglet', 'fonts')
+repo_src = path.join(here, 'pyfiglet', 'fonts-standard')
+if not path.isdir(pkg_src):
+    shutil.copytree(repo_src, pkg_src)
 
 def get_version():
     sys.path.insert(0, 'pyfiglet')


### PR DESCRIPTION
I always get a little nervous when it comes to putting anything in setup.py, but I think this logic is sound...

It looks for a fonts subdirectory and tries to copy fonts-standard if it can't find it.  Should be a NOOP for any build that has already run make.  I think the distribution images should also do nothing here when you try to install them (as they will have the fonts dir built into the package).

I tried a quick wheel and sdist install and it all looked good to me, but I'd appreciate someone else having a think about it...

I also hope I've fixed up my fork so that there is no merging going on...  Please shout if I missed something!