### PR TITLE
Add python3.9 to testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10.11, 3.11.3, pypy3.9]
+        python-version: [3.9.18, 3.10.11, 3.11.3, pypy3.9]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
We think this is the oldest version currently supported.
