### PR TITLE
improve font loader

### DIFF
--- a/pyfiglet/__init__.py
+++ b/pyfiglet/__init__.py
@@ -61,7 +61,16 @@ if sys.platform == 'win32':
     SHARED_DIRECTORY = os.path.join(os.environ["APPDATA"], "pyfiglet")
 else:
     SHARED_DIRECTORY = '/usr/local/share/pyfiglet/'
+    shared_dir_paths = [
+        '/usr/share/figlet/',
+        '/usr/local/share/figlet/',
+        # add figlet shared directory
+    ]
 
+    for path in shared_dir_paths:
+        if os.path.isdir(path):
+            SHARED_DIRECTORY = path
+            break
 
 def figlet_format(text, font=DEFAULT_FONT, **kwargs):
     fig = Figlet(font, **kwargs)
@@ -972,6 +981,7 @@ def main():
     opts, args = parser.parse_args()
 
     if opts.list_fonts:
+        print(f'Current shared directory: {SHARED_DIRECTORY}')
         print('\n'.join(sorted(FigletFont.getFonts())))
         exit(0)
 

--- a/pyfiglet/__init__.py
+++ b/pyfiglet/__init__.py
@@ -60,17 +60,27 @@ RESET_COLORS = b'\033[0m'
 if sys.platform == 'win32':
     SHARED_DIRECTORY = os.path.join(os.environ["APPDATA"], "pyfiglet")
 else:
-    SHARED_DIRECTORY = '/usr/local/share/pyfiglet/'
-    shared_dir_paths = [
+    SEARCHED_DIRECTORIES = [
         '/usr/share/figlet/',
         '/usr/local/share/figlet/',
-        # add figlet shared directory
+        '/usr/local/share/pyfiglet/',
+        # add pyfiglet/figlet shared directory
     ]
 
-    for path in shared_dir_paths:
-        if os.path.isdir(path):
-            SHARED_DIRECTORY = path
-            break
+    DIRECTORIES = []
+    directory_count = (len(SEARCHED_DIRECTORIES) - 1)
+    index = 0
+    while index <= directory_count:
+        directory = SEARCHED_DIRECTORIES[index]
+        if os.path.isdir(directory):
+            DIRECTORIES.append(directory)
+        index += 1
+
+    if len(DIRECTORIES) > 0:
+        SHARED_DIRECTORY = DIRECTORIES[0] # get the first directory found
+    else:
+        print('No share directory found.')
+        exit(0)
 
 def figlet_format(text, font=DEFAULT_FONT, **kwargs):
     fig = Figlet(font, **kwargs)
@@ -982,6 +992,7 @@ def main():
 
     if opts.list_fonts:
         print(f'Current shared directory: {SHARED_DIRECTORY}')
+        print('-------------------------')
         print('\n'.join(sorted(FigletFont.getFonts())))
         exit(0)
 

--- a/pyfiglet/__init__.py
+++ b/pyfiglet/__init__.py
@@ -78,7 +78,7 @@ def openFont(font):
                         break
     # in case of same name but not the same file extension
     for extension in ('tlf', 'flf'):
-        fn = os.path.join(font, extension)
+        fn = os.path.join(font.split('.')[0], extension)
         path = os.path.join(font_path, fn)
         if os.path.isfile(path):
             font_path = path

--- a/pyfiglet/__init__.py
+++ b/pyfiglet/__init__.py
@@ -69,6 +69,13 @@ def openFont(font):
     font_path = '/usr/local/share/pyfiglet' # default path
     if sys.platform == 'win32':
         font_path = os.path.join(os.environ["APPDATA"], "pyfiglet")
+        # in case of same name but not the same file extension
+        for extension in ('tlf', 'flf'):
+            fn = os.path.join(font, extension)
+            path = os.path.join(font_path, fn)
+            if os.path.isfile(path):
+                font_path = path
+                break
     else:
         for directory in SHARED_DIRECTORIES:
             if os.path.isdir(directory):
@@ -76,13 +83,14 @@ def openFont(font):
                     if file.split('.')[0] == font.split('.')[0]:
                         font_path = os.path.join(directory, file)
                         break
-    # in case of same name but not the same file extension
-    for extension in ('tlf', 'flf'):
-        fn = os.path.join(font, extension)
-        path = os.path.join(font_path, fn)
-        if os.path.isfile(path):
-            font_path = path
-            break
+        # in case of same name but not the same file extension
+        for extension in ('tlf', 'flf'):
+            fn = os.path.join(font, extension)
+            path = os.path.join(font_path, fn)
+            if os.path.isfile(path):
+                font_path = path
+                break
+
     return pathlib.Path(font_path)
 
 def figlet_format(text, font=DEFAULT_FONT, **kwargs):

--- a/pyfiglet/__init__.py
+++ b/pyfiglet/__init__.py
@@ -58,10 +58,10 @@ COLOR_CODES = {'BLACK': 30, 'RED': 31, 'GREEN': 32, 'YELLOW': 33, 'BLUE': 34, 'M
 RESET_COLORS = b'\033[0m'
 
 SHARED_DIRECTORIES = [
-    '/usr/share/figlet',
-    '/usr/share/pyfiglet',
     '/usr/local/share/figlet',
     '/usr/local/share/pyfiglet',
+    '/usr/share/figlet',
+    '/usr/share/pyfiglet',
     # add figlet/pyfiglet shared directory path
 ]
 

--- a/pyfiglet/__init__.py
+++ b/pyfiglet/__init__.py
@@ -76,13 +76,13 @@ def openFont(font):
                     if file.split('.')[0] == font.split('.')[0]:
                         font_path = os.path.join(directory, file)
                         break
-        # in case of same name but not the same file extension
-        for extension in ('tlf', 'flf'):
-            fn = os.path.join(font, extension)
-            path = os.path.join(font_path, fn)
-            if os.path.isfile(path):
-                font_path = path
-                break
+    # in case of same name but not the same file extension
+    for extension in ('tlf', 'flf'):
+        fn = os.path.join(font, extension)
+        path = os.path.join(font_path, fn)
+        if os.path.isfile(path):
+            font_path = path
+            break
     return pathlib.Path(font_path)
 
 def figlet_format(text, font=DEFAULT_FONT, **kwargs):

--- a/pyfiglet/__init__.py
+++ b/pyfiglet/__init__.py
@@ -68,7 +68,12 @@ SHARED_DIRECTORIES = [
 def openFont(font):
     font_path = '/usr/local/share/pyfiglet' # default path
     if sys.platform == 'win32':
-        font_path = os.path.join(os.environ["APPDATA"], "pyfiglet")
+        directory = os.path.join(os.environ["APPDATA"], "pyfiglet")
+        if os.path.isdir(directory):
+            for file in os.listdir(directory):
+                if file.split('.')[0] == font.split('.')[0]:
+                    font_path = os.path.join(directory, file)
+                    break
     else:
         for directory in SHARED_DIRECTORIES:
             if os.path.isdir(directory):
@@ -76,14 +81,6 @@ def openFont(font):
                     if file.split('.')[0] == font.split('.')[0]:
                         font_path = os.path.join(directory, file)
                         break
-    # in case of same name but not the same file extension
-    for extension in ('tlf', 'flf'):
-        fn = os.path.join(font.split('.')[0], extension)
-        path = os.path.join(font_path, fn)
-        if os.path.isfile(path):
-            font_path = path
-            break
-
     return pathlib.Path(font_path)
 
 def figlet_format(text, font=DEFAULT_FONT, **kwargs):

--- a/pyfiglet/__init__.py
+++ b/pyfiglet/__init__.py
@@ -58,15 +58,15 @@ COLOR_CODES = {'BLACK': 30, 'RED': 31, 'GREEN': 32, 'YELLOW': 33, 'BLUE': 34, 'M
 RESET_COLORS = b'\033[0m'
 
 SHARED_DIRECTORIES = [
-    '/usr/local/share/figlet',
     '/usr/local/share/pyfiglet',
-    '/usr/share/figlet',
     '/usr/share/pyfiglet',
+    '/usr/local/share/figlet',
+    '/usr/share/figlet',
     # add figlet/pyfiglet shared directory path
 ]
 
 def find_shared_dir():
-    path = ''
+    path = '/usr/local/share/pyfiglet' # default path
     if sys.platform == 'win32':
         path = os.path.join(os.environ["APPDATA"], "pyfiglet")
     else:
@@ -155,8 +155,7 @@ class FigletFont(object):
                 font_path = path
                 break
             else:
-                shared_dir = find_shared_dir()
-                for location in ("./", shared_dir):
+                for location in ("./", find_shared_dir()):
                     full_name = os.path.join(location, fn)
                     if os.path.isfile(full_name):
                         font_path = pathlib.Path(full_name)
@@ -185,8 +184,7 @@ class FigletFont(object):
         if not font.endswith(('.flf', '.tlf')):
             return False
         f = None
-        shared_dir = find_shared_dir()
-        full_file = os.path.join(shared_dir, font)
+        full_file = os.path.join(find_shared_dir(), font)
         if os.path.isfile(font):
             f = open(font, 'rb')
         elif os.path.isfile(full_file):

--- a/pyfiglet/__init__.py
+++ b/pyfiglet/__init__.py
@@ -144,6 +144,13 @@ class FigletFont(object):
             if path.exists():
                 font_path = path
                 break
+            if sys.platform == 'win32':
+                path = os.path.join(os.environ["APPDATA"], "pyfiglet")
+                if os.path.exists(path):
+                    path = os.path.join(path, fn)
+                    if os.path.isfile(path):
+                        font_path = pathlib.Path(path)
+                        break
             else:
                 for directory in SHARED_DIRECTORIES:
                     if os.path.isdir(directory):
@@ -176,12 +183,19 @@ class FigletFont(object):
             return False
         f = None
         full_file = ''
-        for directory in SHARED_DIRECTORIES:
-            if os.path.isdir(directory):
-                path = os.path.join(directory, font)
-                if os.path.isfile(path):
-                    full_file = pathlib.Path(path)
-                    break
+        if sys.platform == 'win32':
+                path = os.path.join(os.environ["APPDATA"], "pyfiglet")
+                if os.path.isdir(path):
+                    path = os.path.join(path, font)
+                    if os.path.isfile(path):
+                        full_file = pathlib.Path(path)
+        else:
+            for directory in SHARED_DIRECTORIES:
+                if os.path.isdir(directory):
+                    path = os.path.join(directory, font)
+                    if os.path.isfile(path):
+                        full_file = pathlib.Path(path)
+                        break
         if os.path.isfile(font):
             f = open(font, 'rb')
         elif os.path.isfile(full_file):
@@ -207,9 +221,14 @@ class FigletFont(object):
     def getFonts(cls):
         all_files = importlib.resources.files('pyfiglet.fonts').iterdir()
         shared_dir = set()
-        for directory in SHARED_DIRECTORIES:
-            if os.path.isdir(directory):
-                shared_dir.update(pathlib.Path(directory).iterdir())
+        if sys.platform == 'win32':
+            path = os.path.join(os.environ["APPDATA"], "pyfiglet")
+            if os.path.isdir(path):
+                shared_dir.update(pathlib.Path(path).iterdir())
+        else:
+            for directory in SHARED_DIRECTORIES:
+                if os.path.isdir(directory):
+                    shared_dir.update(pathlib.Path(directory).iterdir())
         if shared_dir:
             all_files = itertools.chain(all_files, shared_dir)
         else:

--- a/pyfiglet/__init__.py
+++ b/pyfiglet/__init__.py
@@ -69,13 +69,6 @@ def openFont(font):
     font_path = '/usr/local/share/pyfiglet' # default path
     if sys.platform == 'win32':
         font_path = os.path.join(os.environ["APPDATA"], "pyfiglet")
-        # in case of same name but not the same file extension
-        for extension in ('tlf', 'flf'):
-            fn = os.path.join(font, extension)
-            path = os.path.join(font_path, fn)
-            if os.path.isfile(path):
-                font_path = path
-                break
     else:
         for directory in SHARED_DIRECTORIES:
             if os.path.isdir(directory):
@@ -83,13 +76,13 @@ def openFont(font):
                     if file.split('.')[0] == font.split('.')[0]:
                         font_path = os.path.join(directory, file)
                         break
-        # in case of same name but not the same file extension
-        for extension in ('tlf', 'flf'):
-            fn = os.path.join(font, extension)
-            path = os.path.join(font_path, fn)
-            if os.path.isfile(path):
-                font_path = path
-                break
+    # in case of same name but not the same file extension
+    for extension in ('tlf', 'flf'):
+        fn = os.path.join(font, extension)
+        path = os.path.join(font_path, fn)
+        if os.path.isfile(path):
+            font_path = path
+            break
 
     return pathlib.Path(font_path)
 

--- a/pyfiglet/__init__.py
+++ b/pyfiglet/__init__.py
@@ -67,19 +67,22 @@ SHARED_DIRECTORIES = [
 
 def openFont(font):
     font_path = '/usr/local/share/pyfiglet' # default path
-    for directory in SHARED_DIRECTORIES:
-        if os.path.isdir(directory):
-            for file in os.listdir(directory):
-                if file.split('.')[0] == font.split('.')[0]:
-                    font_path = os.path.join(directory, file)
-                    break
-    # in case of same name but not the same file extension
-    for extension in ('tlf', 'flf'):
-        fn = os.path.join(font, extension)
-        path = os.path.join(font_path, fn)
-        if os.path.isfile(path):
-            font_path = path
-            break
+    if sys.platform == 'win32':
+        font_path = os.path.join(os.environ["APPDATA"], "pyfiglet")
+    else:
+        for directory in SHARED_DIRECTORIES:
+            if os.path.isdir(directory):
+                for file in os.listdir(directory):
+                    if file.split('.')[0] == font.split('.')[0]:
+                        font_path = os.path.join(directory, file)
+                        break
+        # in case of same name but not the same file extension
+        for extension in ('tlf', 'flf'):
+            fn = os.path.join(font, extension)
+            path = os.path.join(font_path, fn)
+            if os.path.isfile(path):
+                font_path = path
+                break
     return pathlib.Path(font_path)
 
 def figlet_format(text, font=DEFAULT_FONT, **kwargs):


### PR DESCRIPTION
- use list and loop only for automatic search path of the figlet share directory 
- add current share directory used when you type `pyfiglet -l` like this:
<img width="480" alt="image" src="https://github.com/pwaller/pyfiglet/assets/71203851/f1ea5986-73fc-451f-bfd6-63b1120ba648">

fix for #86 