### PR TITLE
Big type hinting and modernization upgrade

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 build
 pytest
 wheel
+basedpyright

--- a/pyfiglet/__init__.py
+++ b/pyfiglet/__init__.py
@@ -5,7 +5,8 @@
 Python FIGlet adaption
 """
 
-from __future__ import print_function, unicode_literals
+from __future__ import print_function, unicode_literals, annotations
+from typing import Any, Optional
 
 import itertools
 import importlib.resources
@@ -63,12 +64,12 @@ else:
     SHARED_DIRECTORY = '/usr/local/share/pyfiglet/'
 
 
-def figlet_format(text, font=DEFAULT_FONT, **kwargs):
+def figlet_format(text:str, font:str=DEFAULT_FONT, **kwargs:Any):
     fig = Figlet(font, **kwargs)
     return fig.renderText(text)
 
 
-def print_figlet(text, font=DEFAULT_FONT, colors=":", **kwargs):
+def print_figlet(text:str, font:str=DEFAULT_FONT, colors:str=":", **kwargs:Any):
     ansiColors = parse_color(colors)
     if ansiColors:
         sys.stdout.write(ansiColors)
@@ -81,7 +82,7 @@ def print_figlet(text, font=DEFAULT_FONT, colors=":", **kwargs):
 
 
 class FigletError(Exception):
-    def __init__(self, error):
+    def __init__(self, error:str):
         self.error = error
 
     def __str__(self):
@@ -119,17 +120,17 @@ class FigletFont(object):
     reMagicNumber = re.compile(r'^[tf]lf2.')
     reEndMarker = re.compile(r'(.)\s*$')
 
-    def __init__(self, font=DEFAULT_FONT):
+    def __init__(self, font:str=DEFAULT_FONT):
         self.font = font
 
         self.comment = ''
-        self.chars = {}
-        self.width = {}
+        self.chars: dict[int, list[str]] = {}
+        self.width: dict[int, int] = {}
         self.data = self.preloadFont(font)
         self.loadFont()
 
     @classmethod
-    def preloadFont(cls, font):
+    def preloadFont(cls, font:str):
         """
         Load font data if exist
         """
@@ -139,7 +140,7 @@ class FigletFont(object):
         for extension in ('tlf', 'flf'):
             fn = '%s.%s' % (font, extension)
             path = importlib.resources.files('pyfiglet.fonts').joinpath(fn)
-            if path.exists():
+            if path.exists():   # type: ignore
                 font_path = path
                 break
             else:
@@ -168,7 +169,7 @@ class FigletFont(object):
             raise FontNotFound(font)
 
     @classmethod
-    def isValidFont(cls, font):
+    def isValidFont(cls, font:str):
         if not font.endswith(('.flf', '.tlf')):
             return False
         f = None
@@ -204,12 +205,12 @@ class FigletFont(object):
                 if font.is_file() and cls.isValidFont(font.name)]
 
     @classmethod
-    def infoFont(cls, font, short=False):
+    def infoFont(cls, font:str, short:bool=False):
         """
         Get information of font
         """
         data = FigletFont.preloadFont(font)
-        infos = []
+        infos: list[str] = []
         reStartMarker = re.compile(r"""
             ^(FONT|COMMENT|FONTNAME_REGISTRY|FAMILY_NAME|FOUNDRY|WEIGHT_NAME|
               SETWIDTH_NAME|SLANT|ADD_STYLE_NAME|PIXEL_SIZE|POINT_SIZE|
@@ -225,7 +226,7 @@ class FigletFont(object):
         return '\n'.join(infos) if not short else infos[0]
 
     @staticmethod
-    def installFonts(file_name):
+    def installFonts(file_name:str):
         """
         Install the specified font file to this system.
         """
@@ -279,7 +280,7 @@ class FigletFont(object):
                 raise FontError('malformed header for %s' % self.font)
 
             hardBlank = header[0]
-            height, baseLine, maxLength, oldLayout, commentLines = map(
+            height, baseLine, maxLength, oldLayout, commentLines = map( # type: ignore
                 int, header[1:6])
             printDirection = fullLayout = None
 
@@ -310,18 +311,18 @@ class FigletFont(object):
             for i in range(0, commentLines):
                 self.comment += data.pop(0)
 
-            def __char(data):
+            def __char(data: list[str]) -> tuple[int, list[str]]:
                 """
                 Function loads one character in the internal array from font
                 file content
                 """
                 end = None
                 width = 0
-                chars = []
-                for j in range(0, height):
+                chars: list[str] = []
+                for _ in range(0, height):
                     line = data.pop(0)
                     if end is None:
-                        end = self.reEndMarker.search(line).group(1)
+                        end = self.reEndMarker.search(line).group(1)  # type: ignore
                         end = re.compile(re.escape(end) + r'{1,2}\s*$')
 
                     line = end.sub('', line)
@@ -416,15 +417,15 @@ class FigletString(unicode_string):
         '\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef'
         '\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff')
 
-    def reverse(self):
-        out = []
+    def reverse(self) -> FigletString:
+        out: list[str] = []
         for row in self.splitlines():
             out.append(row.translate(self.__reverse_map__)[::-1])
 
         return self.newFromList(out)
 
-    def flip(self):
-        out = []
+    def flip(self) -> FigletString:
+        out: list[str] = []
         for row in self.splitlines()[::-1]:
             out.append(row.translate(self.__flip_map__))
 
@@ -432,8 +433,8 @@ class FigletString(unicode_string):
 
     # doesn't do self.strip() because it could remove leading whitespace on first line of the font
     # doesn't do row.strip() because it could remove empty lines within the font character
-    def strip_surrounding_newlines(self):
-        out = []
+    def strip_surrounding_newlines(self) -> str:
+        out: list[str] = []
         chars_seen = False
         for row in self.splitlines():
             # if the row isn't empty or if we're in the middle of the font character, add the line.
@@ -447,7 +448,7 @@ class FigletString(unicode_string):
     def normalize_surrounding_newlines(self):
         return '\n' + self.strip_surrounding_newlines() + '\n'
 
-    def newFromList(self, list):
+    def newFromList(self, list: list[str]):
         return FigletString('\n'.join(list) + '\n')
 
 
@@ -457,10 +458,10 @@ class FigletRenderingEngine(object):
     including smushing/kerning/justification/direction
     """
 
-    def __init__(self, base=None):
+    def __init__(self, base:Optional[Figlet]=None):
         self.base = base
 
-    def render(self, text):
+    def render(self, text:str):
         """
         Render an ASCII text string in figlet
         """
@@ -482,10 +483,10 @@ class FigletProduct(object):
     the ascii output string
     """
     def __init__(self):
-        self.queue = list()
+        self.queue: list[list[str]] = list()
         self.buffer_string = ""
 
-    def append(self, buffer):
+    def append(self, buffer: list[str]):
         self.queue.append(buffer)
 
     def getString(self):
@@ -496,7 +497,7 @@ class FigletBuilder(object):
     """
     Represent the internals of the build process
     """
-    def __init__(self, text, font, direction, width, justify):
+    def __init__(self, text:str, font:FigletFont, direction:str, width:int, justify:str):
 
         self.text = list(map(ord, list(text)))
         self.direction = direction
@@ -504,15 +505,15 @@ class FigletBuilder(object):
         self.font = font
         self.justify = justify
 
-        self.iterator = 0
-        self.maxSmush = 0
+        self.iterator: int = 0
+        self.maxSmush: int = 0
         self.newBlankRegistered = False
 
-        self.curCharWidth = 0
-        self.prevCharWidth = 0
-        self.currentTotalWidth = 0
+        self.curCharWidth: int = 0
+        self.prevCharWidth: int = 0
+        self.currentTotalWidth: int = 0
 
-        self.blankMarkers = list()
+        self.blankMarkers: list[tuple[list[str], int]] = list()
         self.product = FigletProduct()
         self.buffer = ['' for i in range(self.font.height)]
 
@@ -594,7 +595,7 @@ class FigletBuilder(object):
             string_acc += self.replaceHardblanks(buffer)
         self.product.buffer_string = string_acc
 
-    def getCharAt(self, i):
+    def getCharAt(self, i: int) -> Optional[list[str]]:
         if i < 0 or i >= len(list(self.text)):
             return None
         c = self.text[i]
@@ -604,7 +605,7 @@ class FigletBuilder(object):
         else:
             return self.font.chars[c]
 
-    def getCharWidthAt(self, i):
+    def getCharWidthAt(self, i: int) -> Optional[int]:
         if i < 0 or i >= len(self.text):
             return None
         c = self.text[i]
@@ -613,13 +614,13 @@ class FigletBuilder(object):
         else:
             return self.font.width[c]
 
-    def getCurChar(self):
+    def getCurChar(self) -> Optional[list[str]]:
         return self.getCharAt(self.iterator)
 
     def getCurWidth(self):
         return self.getCharWidthAt(self.iterator)
 
-    def getLeftSmushedChar(self, i, addLeft):
+    def getLeftSmushedChar(self, i:int, addLeft):
         idx = len(addLeft) - self.maxSmush + i
         if idx >= 0 and idx < len(addLeft):
             left = addLeft[idx]
@@ -627,7 +628,7 @@ class FigletBuilder(object):
             left = ''
         return left, idx
 
-    def currentSmushAmount(self, curChar):
+    def currentSmushAmount(self, curChar: list[str]):
         return self.smushAmount(self.buffer, curChar)
 
     def updateSmushedCharInLeftBuffer(self, addLeft, idx, smushed):
@@ -638,7 +639,7 @@ class FigletBuilder(object):
         addLeft = ''.join(l)
         return addLeft
 
-    def smushRow(self, curChar, row):
+    def smushRow(self, curChar:list[str], row:int):
         addLeft = self.buffer[row]
         addRight = curChar[row]
 
@@ -652,7 +653,7 @@ class FigletBuilder(object):
             addLeft = self.updateSmushedCharInLeftBuffer(addLeft, idx, smushed)
         return addLeft, addRight
 
-    def addCurCharRowToBufferRow(self, curChar, row):
+    def addCurCharRowToBufferRow(self, curChar:list[str], row:int):
         addLeft, addRight = self.smushRow(curChar, row)
         self.buffer[row] = addLeft + addRight[self.maxSmush:]
 
@@ -666,7 +667,7 @@ class FigletBuilder(object):
             return
         self.maxSmush = self.currentSmushAmount(curChar)
 
-    def cutBufferAtLastBlank(self, saved_buffer, saved_iterator):
+    def cutBufferAtLastBlank(self, saved_buffer, saved_iterator:int):
         self.product.append(saved_buffer)
         self.iterator = saved_iterator
         self.cutBufferCommon()
@@ -676,7 +677,7 @@ class FigletBuilder(object):
         self.iterator -= 1
         self.cutBufferCommon()
 
-    def blankExist(self, last_blank):
+    def blankExist(self, last_blank:int):
         return last_blank != -1
 
     def getLastBlank(self):
@@ -693,7 +694,7 @@ class FigletBuilder(object):
         else:
             self.cutBufferAtLastChar()
 
-    def justifyString(self, justify, buffer):
+    def justifyString(self, justify:str, buffer:list[str]):
         if justify == 'right':
             for row in range(0, self.font.height):
                 buffer[row] = (
@@ -706,12 +707,12 @@ class FigletBuilder(object):
                         ) + buffer[row]
         return buffer
 
-    def replaceHardblanks(self, buffer):
+    def replaceHardblanks(self, buffer:list[str]):
         string = '\n'.join(buffer) + '\n'
         string = string.replace(self.font.hardBlank, ' ')
         return string
 
-    def smushAmount(self, buffer=[], curChar=[]):
+    def smushAmount(self, buffer:list[str]=[], curChar:list[str]=[]):
         """
         Calculate the amount of smushing we can do between this char and the
         last If this is the first char it will throw a series of exceptions
@@ -762,7 +763,7 @@ class FigletBuilder(object):
 
         return maxSmush
 
-    def smushChars(self, left='', right=''):
+    def smushChars(self, left:str='', right:str=''):
         """
         Given 2 characters which represent the edges rendered figlet
         fonts where they would touch, see if they can be smushed together.
@@ -853,8 +854,8 @@ class Figlet(object):
     Main figlet class.
     """
 
-    def __init__(self, font=DEFAULT_FONT, direction='auto', justify='auto',
-                 width=80):
+    def __init__(self, font:str=DEFAULT_FONT, direction:str='auto', justify:str='auto',
+                 width:int=80) -> None:
         self.font = font
         self._direction = direction
         self._justify = justify
@@ -862,13 +863,14 @@ class Figlet(object):
         self.setFont()
         self.engine = FigletRenderingEngine(base=self)
 
-    def setFont(self, **kwargs):
+    def setFont(self, **kwargs:str) -> None:
         if 'font' in kwargs:
             self.font = kwargs['font']
 
         self.Font = FigletFont(font=self.font)
 
-    def getDirection(self):
+    @property
+    def direction(self):
         if self._direction == 'auto':
             direction = self.Font.printDirection
             if direction == 0:
@@ -881,9 +883,8 @@ class Figlet(object):
         else:
             return self._direction
 
-    direction = property(getDirection)
-
-    def getJustify(self):
+    @property
+    def justify(self):
         if self._justify == 'auto':
             if self.direction == 'left-to-right':
                 return 'left'
@@ -893,17 +894,15 @@ class Figlet(object):
         else:
             return self._justify
 
-    justify = property(getJustify)
-
-    def renderText(self, text):
+    def renderText(self, text:str) -> FigletString:
         # wrapper method to engine
         return self.engine.render(text)
 
-    def getFonts(self):
+    def getFonts(self) -> list[str]:
         return self.Font.getFonts()
 
 
-def color_to_ansi(color, isBackground):
+def color_to_ansi(color:str, isBackground:bool):
     if not color:
         return ''
     color = color.upper()
@@ -923,7 +922,7 @@ def color_to_ansi(color, isBackground):
     return '\033[{}m'.format(ansiCode)
 
 
-def parse_color(color):
+def parse_color(color:str):
     foreground, _, background = color.partition(":")
     ansiForeground = color_to_ansi(foreground, isBackground=False)
     ansiBackground = color_to_ansi(background, isBackground=True)

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,17 @@
+{
+  "include": [
+    "pyfiglet"
+  ],
+
+  "exclude": [
+    "pyfiglet/tests",
+    "pyfiglet/test.py"
+  ],
+
+  "reportMissingImports": "error",
+  "reportMissingTypeStubs": false,
+  "strict": [
+    "pyfiglet"
+  ],
+
+}

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -7,9 +7,7 @@
     "pyfiglet/tests",
     "pyfiglet/test.py"
   ],
-
-  "reportMissingImports": "error",
-  "reportMissingTypeStubs": false,
+  
   "strict": [
     "pyfiglet"
   ],


### PR DESCRIPTION
Hello! So, a bit of explaining is in order. I'm the creator of [Rich-Pyfiglet](https://github.com/edward-jazzhands/rich-pyfiglet) and [Textual-Pyfiglet](https://github.com/edward-jazzhands/textual-pyfiglet/), which are implementations of Pyfiglet for [Rich](https://github.com/Textualize/rich) and [Textual](https://textual.textualize.io/) respectively. Rich-Pyfiglet is a fork of Pyfiglet (you can see in the [forks list](https://github.com/pwaller/pyfiglet/forks)) and then Textual-Pyfiglet uses this fork.

So, I've been working with Pyfiglet for a while. Really big fan. I had noticed in [this post](https://github.com/pwaller/pyfiglet/issues/144#issuecomment-2749105885) on March 24 that you said you were open to PRs for type hints. So thought I would like to tackle this challenge. My two pyfiglet packages pass Pyright and MyPy in strict mode so I set out to try to apply that onto the Pyfiglet package itself.

This doesn't completely add type hints to everything but it does tackle the vast majority of them, basically everything I could figure out easily without needing to dig too deep into the internals. Important to note that there were absolutely no changes to run-time behavior in any way. Aside from a couple standard lib imports (annotations, typing.Any, typing.Optional), every single modification is just adding type hints, except one:
There is also a place in the code where the two uses of the `property()` function were replaced with the @property decorator. This has been in python since the 2.x days so I thought this is a reasonable modification. I suppose it technically counts as a refactor, but hardly ;p. Aside from that, there was no refactoring done.

I have ran the unit tests and confirmed that everything still works perfectly:

pyfiglet/test.py
```
OK = 2238, FAIL = 0
```

pytest -vv
```
============================= test session starts =============================
platform linux -- Python 3.13.3, pytest-8.3.5, pluggy-1.6.0 -- /home/devuser/workspace/vscode-projects/rich-pyfiglet/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/devuser/workspace/vscode-projects/rich-pyfiglet
configfile: pyproject.toml
collected 3 items

pyfiglet/tests/test_cli.py::test_strip PASSED                           [ 33%]
pyfiglet/tests/test_cli.py::test_strip_strange_font PASSED              [ 66%]
pyfiglet/tests/test_cli.py::test_normalize PASSED                       [100%]

============================== 3 passed in 0.35s ==============================
```

For some further evidence that that my changes are good, I'd like to present two files as well that are attached to this post: `pyright_old.txt` and `pyright_new.txt`.
[pyright_old.txt](https://github.com/user-attachments/files/20279333/pyright_old.txt)
[pyright_new.txt](https://github.com/user-attachments/files/20279332/pyright_new.txt)

These results show running Pyright on strict mode. In pyright_old.txt, this shows running Pyright on the original version without any modifications. At the bottom of the file you can see:

```
414 errors, 97 warnings, 0 notes
```

But if you peek inside pyright_new.txt, you will see this:

```
75 errors, 91 warnings, 0 notes
```

That's about an 82% reduction in Pyright warnings. All the public API points are covered, and I also added a `py.typed` file. So this should now be fine to import and use in other programs without needing any # type: ignore comments.

For the record, I also added basedpyright (https://docs.basedpyright.com/) in the dev-requirements.txt, which is an open-source fork of Pyright. I personally prefer it for this kind of work over MyPy because the strict mode will flag every single thing that does not have a type hint, whereas MyPy does not do this and there's no simple way to make it do it that I'm aware of. Adding basedpyright of course required a config file so there's also a pyrightconfig.json file. This will allow any of you that wants to to use it and see the results for yourself.

But, please do look over my work and make sure I didn't make any mistakes. I have not had a second set of eyes overview this. If there's any modifications you want or you'd like me to reduce the scope for a first PR, that's totally fine, just let me know! Hope you like it.